### PR TITLE
fix(修复文章置顶后未被正确解析问题): 实际是未进行解析，直接使用的数据库数据

### DIFF
--- a/components/option-article-top.php
+++ b/components/option-article-top.php
@@ -49,7 +49,7 @@ foreach ($topCids as $key => $value) {
             <section
                 class="cursor-default text-[14px] article-content break-all <?php echo $lineClamp; ?> content-<?php echo $topArticle['cid']; ?>"
                 data-cid="<?php echo $topArticle['cid']; ?>">
-                <?php echo $topArticle['text']; ?>
+                <?php echo $this::markdown($topArticle['text']); ?>
             </section>
             <?php
             if (!$isSingle) {


### PR DESCRIPTION
但依旧应该会存在问题，根据原始代码来看，还有插件处理，markdown判断等问题，根本上还是要解决文章置顶渲染方式问题